### PR TITLE
Add CSP to response headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
 - psql -c "CREATE DATABASE pafs_test WITH ENCODING 'UTF8';" -U postgres
 - cp $TRAVIS_BUILD_DIR/dotenv.travis $TRAVIS_BUILD_DIR/.env
 - cp $TRAVIS_BUILD_DIR/config/database.travis.yml $TRAVIS_BUILD_DIR/config/database.yml
+- cp config/secrets.yml.example config/secrets.yml
 - bundle exec rake pafs_core:install:migrations
 - bundle exec rake db:migrate
 - git config --global user.name "Travis Test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: db14ed3d93b63a9661c718621eec5f758da8837e
+  revision: 6094ff718f0480a36a57bd8ac4d7ef1258b62d77
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -64,13 +64,13 @@ GEM
       airbrake-ruby (~> 1.2)
     airbrake-ruby (1.2.2)
     arel (6.0.4)
-    aws-sdk (2.8.2)
-      aws-sdk-resources (= 2.8.2)
-    aws-sdk-core (2.8.2)
+    aws-sdk (2.8.5)
+      aws-sdk-resources (= 2.8.5)
+    aws-sdk-core (2.8.5)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.2)
-      aws-sdk-core (= 2.8.2)
+    aws-sdk-resources (2.8.5)
+      aws-sdk-core (= 2.8.5)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     benchmark-ips (2.7.2)
@@ -413,4 +413,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,24 @@
 # Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
+  include PafsCore::CustomHeaders
+
   helper PafsCore::Engine.helpers
-   # This is a nested template that ultimately calls the gov uk template layout
+
+  # This is a nested template that ultimately calls the gov uk template layout
   # This allows us to auto insert code into any of the hooks provided by the GDS layout.
   layout ->(_) { "pafs" }
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :custom_headers
+
+  private
+
+  def custom_headers
+    response_headers!(response)
+  end
+
 end

--- a/spec/requests/response_headers_spec.rb
+++ b/spec/requests/response_headers_spec.rb
@@ -1,0 +1,29 @@
+# Play nice with Ruby 3 (and rubocop)
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Response headers", type: :request do
+  describe "Cache busting" do
+    it "contains the headers needed to stop the client caching responses" do
+      get "/"
+
+      expect(response.headers["Cache-Control"]).to eq "no-cache, no-store, max-age=0, must-revalidate, private"
+      expect(response.headers["Pragma"]).to eq "no-cache"
+      expect(response.headers["Expires"]).to eq "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+  end
+
+  describe "Content security policy" do
+    it "contains the headers needed to ensure all content comes from the service" do
+      get "/"
+
+      expect(response.headers["Content-Security-Policy"]).to eq(
+        "default-src 'self'; "\
+        "script-src 'self' 'unsafe-inline'; "\
+        "font-src 'self' data:; "\
+        "report-uri https://environmentagency.report-uri.io/r/default/csp/enforce"
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,14 +44,14 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
Following a PEN test it was flagged that the service has not specified a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in the response headers sent back from the app to the clients browser.

For reference CSP

> [..] is an HTTP response header that restricts the browser to loading external assets such as scripts, styles or media from a wide variety of sources — as well as inline scripts. It is intended to prevent wide categories of attacks, such as cross-site scripting (XSS), click-jacking and other forms of code injection.
>
> *https://blog.sqreen.io/integrating-content-security-policy-into-your-rails-applications-4f883eed8f45/*

The actual code to customise the response headers is held in [pafs_core](https://github.com/DEFRA/pafs_core/pull/128) so this change updates the `ApplicationController` to pull the `PafsCore::CustomHeaders` module in and ensure all pages that originate from **pafs-user** also apply the CSP.