### PR TITLE
Initialize feedback links in config to real values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 43143d4fc64d948d4fad359cab4d9170295f670f
+  revision: e8836f70d2846c7c9c1851e1962fffb276f8c291
   branch: develop
   specs:
     pafs_core (0.0.2)

--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -1,6 +1,6 @@
 <div class="phase-banner-beta">
   <p>
     <strong class="phase-tag">BETA</strong>
-    <span><%= t(".heading_html", :href => link_to(t(".feedback"), PafsCore.config.banner_feedback_uri)) %></span>
+    <span><%= t(".heading_html", :href => link_to(t(".feedback"), PafsCore.config.banner_feedback_uri, target: '_blank')) %></span>
   </p>
 </div>

--- a/config/initializers/pafs_core_config.rb
+++ b/config/initializers/pafs_core_config.rb
@@ -1,4 +1,4 @@
 PafsCore.configure do |config|
-  # FIXME: workout where this should go ---v
-  config.banner_feedback_uri = "http://google.co.uk"
+  config.complete_page_feedback_uri = "https://www.gov.uk/done/flood-and-coastal-defence-funding-submit-a-project"
+  config.banner_feedback_uri = "http://www.smartsurvey.co.uk/s/PAFSGDS/"
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-310

We have a feedback link in the header and one when the proposal is finally submitted. Prior to this change these links didn't actually point to anything real.

The links come from config values set in an initializer.

This change updates the `pafs_core_config.rb` initializer to ensure the correct, real values are used.