### PR TITLE
Fix issue with Airbrake gem and project_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,14 +85,7 @@ end
 
 group :production, :edge, :qa, :staging do
   gem "rails_12factor"
-  # We have to fix to 5.3 because of a breaking change in 5.4. 5.4 updates
-  # its dependency on airbrake-ruby to 1.4, and it in turn now validates that
-  # both AIRBRAKE_PROJECT_KEY and AIRBRAKE_PROJECT_ID exist, and that
-  # AIRBRAKE_PROJECT_KEY is an integer.
-  # https://github.com/airbrake/airbrake-ruby/pull/87
-  # Its not catastrophic; we simply need to add AIRBRAKE_PROJECT_KEY=1 to our
-  # environments and once there we can then update this gem past version 5.3
-  gem "airbrake", "~> 5.3.0"
+  gem "airbrake", "~> 5.0"
 end
 
 group :benchmark do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (5.3.0)
-      airbrake-ruby (~> 1.3)
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
     airbrake-ruby (1.8.0)
     arel (6.0.4)
     aws-sdk (2.8.10)
@@ -372,7 +372,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.3.0)
+  airbrake (~> 5.0)
   benchmark-ips
   byebug
   capybara

--- a/config/initializers/errbit_airbrake.rb
+++ b/config/initializers/errbit_airbrake.rb
@@ -9,7 +9,7 @@ if defined?(Airbrake) #&& secrets.airbrake_host.present?
     # https://github.com/airbrake/airbrake-ruby#project_id--project_key
     c.host = ENV['AIRBRAKE_HOST']
     c.project_key = ENV['AIRBRAKE_PROJECT_KEY']
-    c.project_id = true # Errbit doesn't require a specific project_id, so setting to true
+    c.project_id = 1
 
     # Configures the root directory of your project. Expects a String or a
     # Pathname, which represents the path to your project. Providing this option


### PR DESCRIPTION
It looks like the info in 8ce2343 was incorrect. It is true that we now need to set `AIRBRAKE_PROJECT_ID` and that the value must be an integer if we are using a later version of Airbrake. What was incorrect was the fact that the value comes from an environment variable.

In fact we set it in an initializer. Hence this change removes the block on airbrake being no greater than version 5.3.0, and updates the initializer with a valid value.