### PR TITLE
Remove turbolinks from project to fix rdo btn select issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "rails", "~> 4.2.7.1"
 # rake 11 can break stuff see: http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11/35893941
 gem "rake", "< 11.0"
 gem "sass-rails", "~> 5.0"
-# gem "haml-rails", "~> 0.9"
 gem "uglifier", ">= 1.3.0"
 gem "coffee-rails", "~> 4.1.0"
 gem "therubyracer", platforms: :ruby
@@ -14,7 +13,6 @@ gem "font-awesome-sass", "~> 4.5.0"
 gem "jquery-rails"
 gem "jquery-turbolinks"
 
-gem "turbolinks"
 gem "jbuilder", "~> 2.0"
 gem "sdoc", "~> 0.4.0", group: :doc
 
@@ -36,12 +34,9 @@ gem "dibble", "~> 0.1",
 gem "govuk_template", "~> 0.17.0"
 # Access to some of the most common styles and scripts used by GDS
 gem "govuk_frontend_toolkit", "~> 4.10.0"
-
+# A gem wrapper around http://github.com/alphagov/govuk_elements that pulls
+# stylesheet and javascript files into a Rails app.
 gem "govuk_elements_rails"
-# gem "govuk_elements_form_builder", git: "https://github.com/ministryofjustice/govuk_elements_form_builder.git"
-# gem "govuk_elements_form_builder",
-#   git: "https://github.com/tonyheadford/govuk_elements_form_builder.git",
-#   branch: "develop"
 
 # active job backend
 gem "sucker_punch", "~> 2.0"
@@ -55,9 +50,6 @@ gem "whenever", require: false
 gem "pafs_core", "~> 0.0",
   git: "https://github.com/DEFRA/pafs_core",
   branch: "develop"
-# gem "cumberland", "~> 0.0.1", git: "https://github.com/DEFRA/cumberland"
-# gem "axlsx", "~>2.1.0.pre"
-# gem "roo"
 
 group :development, :test do
   gem "rspec-rails"
@@ -94,9 +86,3 @@ group :benchmark do
   gem "stackprof"
   gem "rbtrace"
 end
-
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Capistrano for deployment
-#gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,6 @@ DEPENDENCIES
   stackprof
   sucker_punch (~> 2.0)
   therubyracer
-  turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   whenever

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require jquery
 //= require jquery.turbolinks
 //= require jquery_ujs
-//= require turbolinks
 //= require govuk_toolkit
 //= require pafs_core/application
 //= require_tree .

--- a/app/views/layouts/pafs.html.erb
+++ b/app/views/layouts/pafs.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:head) do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", media: "all" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
   <meta name="format-detection" content="telephone=no" />
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= javascript_include_tag "application" %>
 <% end %>
 <% unless content_for? :page_title %>
   <% if @project.try(:step) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170328094333) do
+ActiveRecord::Schema.define(version: 20170403103416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We recently found that the radio buttons were not correctly highlighting when selected (post 0e43cee). This appeared to be a recent change following running a bundle update against the project.

Initially we looked at the GOVUK gems which are responsible for the majority of the lyaout and styling, and spotted they had indeed been updated. However reverting them to previous versions did not seem to resolve the issue.

It was then we instead looked at whether [Turbolinks](https://github.com/turbolinks/turbolinks) was at fault (the fact that a forced reload of the page was the initial clue). By removing Turbolinks from the project we found the problem went away. We also spotted that Turbolinks had gone from version 2 to version 5 during the recent bundle update so we are now confident it is the root cause.

In order to keep the latest Turbolinks we would need to amend the document load call within the template, which is difficult as it comes from the GOV.UK gem. We could instead have gone back to the previous version and locked the project to it. However after some discussion we felt it would be better to go with removing Turbolinks as this is not a project that will greatly benefit from using it, and we run the risk of wasting time trying to solve similar issues in the future.