### PR TITLE
[PK-972] Amend the request account page to include access needed

### DIFF
--- a/config/locales/account_requests.en.yml
+++ b/config/locales/account_requests.en.yml
@@ -1,13 +1,4 @@
 en:
-  activerecord:
-    attributes:
-      account_request:
-        first_name: "First name"
-        last_name: "Last name"
-        email: "Work email address"
-        telephone_number: "Telephone number"
-        organisation: "Organisation"
-        job_title: "Job title"
   account_requests:
     new:
       heading: "Request an account"


### PR DESCRIPTION
[PK-972] Amend the request account page to include access needed

Removes `PafsCore::AccountRequest`'s locale which was not being used due to the namespace not being quite right.

Have moved this into pafs_core, with the correct namespace.

https://github.com/DEFRA/pafs_core/pull/170