### PR TITLE
[PM-436] Extract flag to allow PSOs to create proposals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem "database_cleaner"
   gem "simplecov", require: false
   gem "codeclimate-test-reporter", "~> 0.6", require: false
+  gem "climate_control"
 end
 
 group :production, :edge, :qa, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: d9a4eb2ba4dea3678802e7a3fc68f4424735fc05
+  revision: 8ead02ae37c03cc937c9d4abae4bd089aab4a93b
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -76,13 +76,13 @@ GEM
     airbrake-ruby (1.8.0)
     arel (6.0.4)
     aws-eventstream (1.0.3)
-    aws-sdk (2.11.279)
-      aws-sdk-resources (= 2.11.279)
-    aws-sdk-core (2.11.279)
+    aws-sdk (2.11.281)
+      aws-sdk-resources (= 2.11.281)
+    aws-sdk-core (2.11.281)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.279)
-      aws-sdk-core (= 2.11.279)
+    aws-sdk-resources (2.11.281)
+      aws-sdk-core (= 2.11.281)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
@@ -104,6 +104,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     clamav-client (3.1.0)
+    climate_control (0.2.0)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.2)
@@ -318,7 +319,7 @@ GEM
       nokogiri (>= 1.4.4)
       rubyzip (>= 1.1.6)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -389,6 +390,7 @@ DEPENDENCIES
   benchmark-ips
   byebug
   capybara
+  climate_control
   codeclimate-test-reporter (~> 0.6)
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/spec/features/projects/bootstrap_spec.rb
+++ b/spec/features/projects/bootstrap_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature 'Creating a project', type: :feature do
-  context 'without FORCE_PSO_TO_POL set' do
+  context 'without PSO_CANNOT_CREATE_PROJECTS set' do
     context 'as an rma user' do
       let(:user) { create(:account_user, :rma) }
 
@@ -29,9 +29,11 @@ RSpec.feature 'Creating a project', type: :feature do
     end
   end
 
-  context 'with FORCE_PSO_TO_POL set' do
-    before do
-      allow(ENV).to receive(:fetch).with('FORCE_PSO_TO_POL', false).and_return(true)
+  context 'with PSO_CANNOT_CREATE_PROJECTS set' do
+    around do |example|
+      with_modified_env PSO_CANNOT_CREATE_PROJECTS: '1' do
+        example.run
+      end
     end
 
     context 'as an rma user' do

--- a/spec/features/projects/viewing_spec.rb
+++ b/spec/features/projects/viewing_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 FLAG_DISABLED_SPECS = [
   { user_type: :rma, project_area: :pso_area, project_state: :draft,    can_change_state: true, can_edit: true },
   { user_type: :rma, project_area: :rma_area, project_state: :draft,    can_change_state: true, can_edit: true },
@@ -99,8 +98,10 @@ RSpec.feature 'Viewing a project', type: :feature do
 
   context 'with FORCE_PSO_TO_POL set' do
     FLAG_ENABLED_SPECS.each do |spec|
-      before do
-        allow(ENV).to receive(:fetch).with('FORCE_PSO_TO_POL', false).and_return(true)
+      around do |example|
+        with_modified_env FORCE_PSO_TO_POL: '1' do
+          example.run
+        end
       end
 
       run_spec_configuration(spec)

--- a/spec/support/climate_control.rb
+++ b/spec/support/climate_control.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ClimateControlHelper
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ClimateControlHelper
+end


### PR DESCRIPTION
* Need to make the creation independent from the other changes to PSO permissions.
* Moved from FORCE_PSO_TO_POL to PSO_CANNOT_CREATE_PROJECTS
* Defaults to 'false' i.e. with the flag not set, we allow PSOs to create projects
* Add climate control to ease env var testing