### PR TITLE
Bump pafs_core version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rake"
 gem 'sass-rails', '~> 5.0'
 gem "uglifier"
 gem "coffee-rails"
-gem "therubyracer", platforms: :ruby
+gem 'mini_racer', '~> 0.4.0'
 
 gem "font-awesome-sass", "~> 4.5.0"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 1041751cbb412c3f0948d534fa7d30e3f75e99a0
+  revision: 7cabb58672bc8ee455b44c15276de3dd9f8f11fb
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -87,9 +87,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrake (13.0.2)
+    airbrake (13.0.3)
       airbrake-ruby (~> 6.0)
-    airbrake-ruby (6.1.1)
+    airbrake-ruby (6.2.0)
       rbtree3 (~> 0.5)
     async (1.30.3)
       console (~> 1.10)
@@ -111,8 +111,8 @@ GEM
     async-pool (0.3.10)
       async (>= 1.25)
     aws-eventstream (1.2.0)
-    aws-partitions (1.623.0)
-    aws-sdk-core (3.136.0)
+    aws-partitions (1.635.0)
+    aws-sdk-core (3.153.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -300,7 +300,7 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
-    libv8 (3.16.14.19)
+    libv8-node (15.14.0.1)
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -308,7 +308,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.6)
@@ -322,6 +322,8 @@ GEM
     mime-types-data (3.2020.0512)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.16.3)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -415,7 +417,6 @@ GEM
       optimist (>= 3.0.0)
     rbtree3 (0.7.0)
     rdoc (6.3.2)
-    ref (2.0.0)
     regexp_parser (2.4.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -505,9 +506,6 @@ GEM
     statsd-ruby (1.5.0)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -574,6 +572,7 @@ DEPENDENCIES
   jquery-turbolinks
   kaminari
   letter_opener
+  mini_racer (~> 0.4.0)
   overcommit
   pafs_core (~> 0.0)!
   passenger (~> 5.1)
@@ -592,7 +591,6 @@ DEPENDENCIES
   spring
   stackprof
   sucker_punch (~> 2.0)
-  therubyracer
   uglifier
   web-console
   whenever


### PR DESCRIPTION
This change swaps out `therubyracer` for `mini_racer` and bumps the engine version to pick up the `ApplicationController` namespace fix.
https://eaflood.atlassian.net/browse/RUBY-2108 