### PR TITLE
Page titles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 4e28f849dcdc53f6c736ef2fbd705aa0a7d36323
+  revision: b0b351a28dc92a10da7240800776536ecbac43fd
   branch: main
   specs:
     pafs_core (0.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     async-pool (0.3.10)
       async (>= 1.25)
     aws-eventstream (1.2.0)
-    aws-partitions (1.651.0)
+    aws-partitions (1.655.0)
     aws-sdk-core (3.166.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -196,7 +196,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.23.0)
+    faker (3.0.0)
       i18n (>= 1.8.11, < 2)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
@@ -302,7 +302,7 @@ GEM
       net-protocol
     net-protocol (0.1.3)
       timeout
-    net-smtp (0.3.2)
+    net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.9)
@@ -415,7 +415,7 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
-    rubocop (1.37.1)
+    rubocop (1.38.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
@@ -433,7 +433,7 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.14.2)
+    rubocop-rspec (2.15.0)
       rubocop (~> 1.33)
     ruby-prof (1.4.3)
     ruby-progressbar (1.11.0)
@@ -517,7 +517,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.4)
 
 PLATFORMS
   ruby

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,10 +2,6 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def make_page_title(title)
-    "#{title} - #{t(:global_proposition_header)} - GOV.UK"
-  end
-
   def revision_hash
     Rails.application.config.x.revision
   end

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, make_page_title("Account request") %>
+<% content_for :title, "Account request" %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t(".heading") %></h1>
     <p><%= t(".description") %></p>
     <%= pafs_form_for @account_request do |f| %>
-      <%= f.error_header %>
+      <%= form_error_header(f) %>
       <div class="form-group">
         <%= f.text_field :first_name, class: "form-control form-wide" %>
         <%= f.text_field :last_name, class: "form-control form-wide" %>

--- a/app/views/account_requests/show.html.erb
+++ b/app/views/account_requests/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, make_page_title("Account request confirmation") %>
+<% content_for :title, "Account request confirmation" %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="confirmation-box">

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, make_page_title("Set a password") %>
+<% content_for :title, "Set a password" %>
 <% migrate_devise_errors_for(resource) %>
 <%= pafs_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
-  <%= f.error_header "Check your details", "The following error(s) prevented your password being set:" %>
+  <%= form_error_header(f, "Check your details", "The following error(s) prevented your password being set:") %>
   <%#= devise_error_messages! %>
   <%= f.hidden_field :invitation_token %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, make_page_title("Change password") %>
+<% content_for :title, "Change password" %>
 <% migrate_devise_errors_for resource %>
 <%= pafs_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_header("Check your sign in details", "") %>
+  <%= form_error_header(f, "Check your sign in details", "") %>
   <h1 class="heading-large">Reset password</h1>
   <div class="form-hint password-instructions">Your password must contain a minimum of:
     <ul class="list-bullet">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, make_page_title("Password reset") %>
+<% content_for :title, "Password reset" %>
 <% migrate_devise_errors_for resource %>
 <%= pafs_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_header("Check your sign in details", "") %>
+  <%= form_error_header(f, "Check your sign in details", "") %>
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">Reset your password</h1>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, make_page_title("Sign in") %>
+<% content_for :title, "Sign in" %>
 <%
   if flash[:alert].present?
     resource.errors.add(:base, flash[:alert])
   end
 %>
 <%= pafs_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <%= f.error_header("Check your sign in details", "") %>
+  <%= form_error_header(f, "Check your sign in details", "") %>
   <h1 class="heading-large">Sign in</h2>
   <%= f.form_group(:base) do %>
     <%= f.error_message(:base) %>

--- a/app/views/layouts/pafs.html.erb
+++ b/app/views/layouts/pafs.html.erb
@@ -5,13 +5,8 @@
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
   <meta name="format-detection" content="telephone=no" />
 <% end %>
-<% unless content_for? :page_title %>
-  <% if @project.try(:step) %>
-    <% content_for :page_title, make_page_title(t(@project.step, scope: "page_titles")) %>
-  <% else %>
-    <% content_for :page_title, make_page_title(t(:global_proposition_header)) %>
-  <% end %>
-<% end %>
+
+<% content_for :page_title, title %>
 
 <% content_for :body_start do %><%= render "shared/cookie_message" %><% end %>
 <% content_for :cookie_message do %><% end %>

--- a/app/views/pages/pafs_cookie_policy.html.erb
+++ b/app/views/pages/pafs_cookie_policy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, make_page_title("Cookies") %>
+<% content_for :title, "Cookies" %>
 
 <header class="text margin-top">
   <h1 class="form-title heading-xlarge">

--- a/app/views/pages/pafs_privacy_policy.html.erb
+++ b/app/views/pages/pafs_privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, make_page_title("Privacy") %>
+<% content_for :title, "Privacy" %>
 
 <header class="text margin-top">
   <h1 class="form-title heading-large">

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, make_page_title("Start") %>
+<% content_for :title, "Start" %>
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Submit a proposal for flood and coastal erosion risk management project funding</h1>

--- a/app/views/reset_password/reset.html.erb
+++ b/app/views/reset_password/reset.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, make_page_title("Reset password confirmation") %>
+<% content_for :title, "Reset password confirmation" %>
 <div class="step-container">
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/spec/features/projects/bootstrap_spec.rb
+++ b/spec/features/projects/bootstrap_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Creating a project" do
     context "with a pso user" do
       let(:user) { create(:account_user, :pso) }
 
-      it "ets me bootstrap a project" do
+      it "lets me bootstrap a project" do
         login_as(user)
         bootstrap_a_new_proposal(
           type: "DEF",

--- a/spec/support/features/proposal_steps.rb
+++ b/spec/support/features/proposal_steps.rb
@@ -26,7 +26,7 @@ module Features
     end
 
     def enter_the_proposal_name(name)
-      expect(page).to have_selector("h1", text: "What is the project's name?")
+      expect(page).to have_selector("h1", text: "What is the project’s name?")
 
       fill_in "Project name", with: name
       click_on "Save and continue"


### PR DESCRIPTION
This change aligns page titles with H1 content. It also prepends "Error - " to the page title if there are form errors.
https://eaflood.atlassian.net/browse/RUBY-2152
https://eaflood.atlassian.net/browse/RUBY-2153