### PR TITLE
RUBY-2729: adjusting fixture data as sub_type is now mandatory field for pso areas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 5795b82a5f4d4b9d88abce30cdc2a9eb191665fe
+  revision: 3de329d8bbf87a713bb00c88bd900f7466a81b66
   branch: main
   specs:
     pafs_core (0.0.2)
@@ -124,16 +124,16 @@ GEM
     async-pool (0.4.0)
       async (>= 1.25)
     aws-eventstream (1.2.0)
-    aws-partitions (1.820.0)
-    aws-sdk-core (3.181.0)
+    aws-partitions (1.832.0)
+    aws-sdk-core (3.185.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.71.0)
-      aws-sdk-core (~> 3, >= 3.177.0)
+    aws-sdk-kms (1.72.0)
+      aws-sdk-core (~> 3, >= 3.184.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.134.0)
+    aws-sdk-s3 (1.136.0)
       aws-sdk-core (~> 3, >= 3.181.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.6)
@@ -209,7 +209,8 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.7.10)
+    faraday (2.7.11)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-http-cache (2.5.0)
@@ -296,7 +297,7 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.4)
@@ -501,7 +502,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_20_214333) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_02_152826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -73,6 +73,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_20_214333) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "sub_type"
+    t.string "identifier"
+    t.date "end_date"
     t.index ["name"], name: "index_pafs_core_areas_on_name"
   end
 

--- a/lib/fixtures/areas/areas.csv
+++ b/lib/fixtures/areas/areas.csv
@@ -15,48 +15,48 @@ Hertfordshire and North London,England,EA Area,
 Solent and South Downs,England,EA Area,
 Kent South London and East Sussex,England,EA Area,
 EA Test Area,England,EA Area,
-PSO Cumbria,Cumbria and Lancashire,PSO Area,
-PSO Lancashire,Cumbria and Lancashire,PSO Area,
-PSO East Devon and Cornwall,Devon Cornwall and the Isles of Scilly,PSO Area,
-PSO West Devon and Cornwall,Devon Cornwall and the Isles of Scilly,PSO Area,
-PSO Cambridge and Bedfordshire,East Anglia,PSO Area,
-PSO Coastal Essex Suffolk and Norfolk,East Anglia,PSO Area,
-PSO Essex,East Anglia,PSO Area,
-PSO Norfolk and Suffolk,East Anglia,PSO Area,
-PSO Derbyshire and Leicestershire,East Midlands,PSO Area,
-PSO Nottinghamshire and Tidal Trent,East Midlands,PSO Area,
-PSO Cheshire and Merseyside,Greater Manchester Merseyside and Cheshire,PSO Area,
-PSO Greater Manchester,Greater Manchester Merseyside and Cheshire,PSO Area,
-PSO London East,Hertfordshire and North London,PSO Area,
-PSO London West,Hertfordshire and North London,PSO Area,
-PSO Luton Hertfordshire and Essex,Hertfordshire and North London,PSO Area,
-PSO East Kent,Kent South London and East Sussex,PSO Area,
-PSO South East London and North Kent,Kent South London and East Sussex,PSO Area,
-PSO South West London and Mole,Kent South London and East Sussex,PSO Area,
-PSO West Kent,Kent South London and East Sussex,PSO Area,
-PSO Coastal Lincolnshire and Northamptonshire,Lincolnshire and Northamptonshire,PSO Area,
-PSO Lincolnshire,Lincolnshire and Northamptonshire,PSO Area,
-PSO Welland and Nene,Lincolnshire and Northamptonshire,PSO Area,
-PSO Durham and Tees Valley,North East,PSO Area,
-PSO Tyne and Wear and Northumberland,North East,PSO Area,
-PSO East Sussex,Solent and South Downs,PSO Area,
-PSO Hampshire and Isle of Wight,Solent and South Downs,PSO Area,
-PSO West Sussex,Solent and South Downs,PSO Area,
-PSO Berkshire and Buckinghamshire,Thames,PSO Area,
-PSO Oxfordshire,Thames,PSO Area,
-PSO Surrey,Thames,PSO Area,
-PSO Dorset and Wiltshire,Wessex,PSO Area,
-PSO Somerset,Wessex,PSO Area,
-PSO West of England,Wessex,PSO Area,
-PSO Herefordshire and Gloucestershire,West Midlands,PSO Area,
-PSO Shropshire Worcestershire Telford and Wrekin,West Midlands,PSO Area,
-PSO Staffordshire and the Black Country,West Midlands,PSO Area,
-PSO Warwickshire Birmingham Solihull and Coventry,West Midlands,PSO Area,
-PSO East Yorkshire,Yorkshire,PSO Area,
-PSO North Yorkshire,Yorkshire,PSO Area,
-PSO South Yorkshire,Yorkshire,PSO Area,
-PSO West Yorkshire,Yorkshire,PSO Area,
-PSO Test Area,EA Test Area,PSO Area,
+PSO Cumbria,Cumbria and Lancashire,PSO Area,NW
+PSO Lancashire,Cumbria and Lancashire,PSO Area,NW
+PSO East Devon and Cornwall,Devon Cornwall and the Isles of Scilly,PSO Area,SW
+PSO West Devon and Cornwall,Devon Cornwall and the Isles of Scilly,PSO Area,SW
+PSO Cambridge and Bedfordshire,East Anglia,PSO Area,AC
+PSO Coastal Essex Suffolk and Norfolk,East Anglia,PSO Area,AE
+PSO Essex,East Anglia,PSO Area,AE
+PSO Norfolk and Suffolk,East Anglia,PSO Area,AE
+PSO Derbyshire and Leicestershire,East Midlands,PSO Area,TR
+PSO Nottinghamshire and Tidal Trent,East Midlands,PSO Area,TR
+PSO Cheshire and Merseyside,Greater Manchester Merseyside and Cheshire,PSO Area,NW
+PSO Greater Manchester,Greater Manchester Merseyside and Cheshire,PSO Area,NW
+PSO London East,Hertfordshire and North London,PSO Area,TH
+PSO London West,Hertfordshire and North London,PSO Area,TH
+PSO Luton Hertfordshire and Essex,Hertfordshire and North London,PSO Area,TH
+PSO East Kent,Kent South London and East Sussex,PSO Area,SO
+PSO South East London and North Kent,Kent South London and East Sussex,PSO Area,TH
+PSO South West London and Mole,Kent South London and East Sussex,PSO Area,TH
+PSO West Kent,Kent South London and East Sussex,PSO Area,SO
+PSO Coastal Lincolnshire and Northamptonshire,Lincolnshire and Northamptonshire,PSO Area,AN
+PSO Lincolnshire,Lincolnshire and Northamptonshire,PSO Area,AN
+PSO Welland and Nene,Lincolnshire and Northamptonshire,PSO Area,AN
+PSO Durham and Tees Valley,North East,PSO Area,NO
+PSO Tyne and Wear and Northumberland,North East,PSO Area,NO
+PSO East Sussex,Solent and South Downs,PSO Area,SO
+PSO Hampshire and Isle of Wight,Solent and South Downs,PSO Area,SO
+PSO West Sussex,Solent and South Downs,PSO Area,SO
+PSO Berkshire and Buckinghamshire,Thames,PSO Area,TH
+PSO Oxfordshire,Thames,PSO Area,TH
+PSO Surrey,Thames,PSO Area,TH
+PSO Dorset and Wiltshire,Wessex,PSO Area,WX
+PSO Somerset,Wessex,PSO Area,WX
+PSO West of England,Wessex,PSO Area,WX
+PSO Herefordshire and Gloucestershire,West Midlands,PSO Area,SN
+PSO Shropshire Worcestershire Telford and Wrekin,West Midlands,PSO Area,SN
+PSO Staffordshire and the Black Country,West Midlands,PSO Area,TR
+PSO Warwickshire Birmingham Solihull and Coventry,West Midlands,PSO Area,SN
+PSO East Yorkshire,Yorkshire,PSO Area,YO
+PSO North Yorkshire,Yorkshire,PSO Area,YO
+PSO South Yorkshire,Yorkshire,PSO Area,YO
+PSO West Yorkshire,Yorkshire,PSO Area,YO
+PSO Test Area,EA Test Area,PSO Area,NW
 Adur and Worthing Councils,PSO West Sussex,RMA,LA
 Adur District Council,PSO West Sussex,RMA,LA
 Ainsty (2008) IDB,PSO North Yorkshire,RMA,IDB


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2729
main fix was applied to pafs_core, here we're just  updating fixture data