### PR TITLE
Update pafs_core to revision dfc779a

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 1368e4c2592504c4d9386f42a95c1e0d0b57db35
+  revision: dfc779a09bef45df1c1caf72547e515508daba9d
   branch: main
   specs:
-    pafs_core (0.0.2)
+    pafs_core (1.0.1)
       aws-sdk-s3
       bstard
       clamav-client
@@ -130,23 +130,23 @@ GEM
       faraday
     async-pool (0.10.3)
       async (>= 1.25)
-    aws-eventstream (1.3.2)
-    aws-partitions (1.1084.0)
-    aws-sdk-core (3.222.1)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1116.0)
+    aws-sdk-core (3.225.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.99.0)
-      aws-sdk-core (~> 3, >= 3.216.0)
+    aws-sdk-kms (1.105.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.183.0)
-      aws-sdk-core (~> 3, >= 3.216.0)
+    aws-sdk-s3 (1.189.1)
+      aws-sdk-core (~> 3, >= 3.225.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.11.0)
+    aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -559,7 +559,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.9.1)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
- Bump pafs_core from 0.0.2 to 1.0.1 at revision dfc779a09bef45df1c1caf72547e515508daba9d
- Upgrade aws-sdk-core, aws-sdk-kms, aws-sdk-s3, aws-eventstream, aws-partitions, and aws-sigv4 to latest versions
- Update websocket-driver from
